### PR TITLE
Added support for numeric IP baseUrls

### DIFF
--- a/R/WebApiTools.R
+++ b/R/WebApiTools.R
@@ -236,9 +236,14 @@ insertConceptSetConceptIdsInPackage <- function(fileName, baseUrl) {
 }
 
 .checkBaseUrl <- function(baseUrl) {
-  return(grepl(pattern = "https?:\\/\\/[a-z0-9]+([\\-\\.]{1}[a-z0-9]+)*\\.[a-z]{2,5}(:[0-9]{1,5})+(\\/.*)?\\/WebAPI$",
-               x = baseUrl,
-               ignore.case = FALSE))
+  patterns <- list("https?:\\/\\/[a-z0-9]+([\\-\\.]{1}[a-z0-9]+)*\\.[a-z]{2,5}(:[0-9]{1,5})+(\\/.*)?\\/WebAPI$",
+                   "https?:\\/\\/(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(:[0-9]{1,5})+(\\/.*)?\\/WebAPI$")
+  results <- lapply(patterns, function(p) {
+    result <- grepl(pattern = p, 
+                    x = baseUrl, 
+                    ignore.case = FALSE)
+  })
+  return(any(as.logical(results)))
 }
 
 

--- a/tests/testthat/test-webApiTools.R
+++ b/tests/testthat/test-webApiTools.R
@@ -1,14 +1,19 @@
 library("testthat")
 
+validBaseUrl <- "http://api.ohdsi.org:80/WebAPI"
+
 test_that("Invalid source key", {
-  expect_error(object = getCohortGenerationStatuses(baseUrl = "http://api.ohdsi.org:80/WebAPI", definitionIds = c(1234), sourceKeys = c("blah")))
-  expect_error(object = invokeCohortSetGeneration(baseUrl = "http://api.ohdsi.org:80/WebAPI", definitionIds = c(1234), sourceKeys = c("blah")))
+  expect_error(object = getCohortGenerationStatuses(baseUrl = validBaseUrl, definitionIds = c(1234), sourceKeys = c("blah")))
+  expect_error(object = invokeCohortSetGeneration(baseUrl = validBaseUrl, definitionIds = c(1234), sourceKeys = c("blah")))
 })
 
 test_that("Invalid base Url", {
-  expect_error(object = getCohortDefinitionName(baseUrl = "blah", definitionId = 1234))
-  expect_error(object = getConceptSetConceptIds(baseUrl = "blah", setId = 1234))
-  expect_error(object = insertCohortDefinitionSetInPackage(baseUrl = "blah", fileName = "conceptsetids.csv"))
-  expect_error(object = getCohortGenerationStatuses(baseUrl = "blah", definitionIds = c(1234), sourceKeys = c("CDM")))
-  expect_error(object = invokeCohortSetGeneration(baseUrl = "blah", definitionIds = c(1234), sourceKeys = c("CDM")))
+  baseUrls <- c("blah", "256.256.256.256:80/WebAPI", "1.1:80/WebAPI", "1.1.1.255/webapi")
+  for (baseUrl in baseUrls) {
+    expect_error(object = getCohortDefinitionName(baseUrl = baseUrl, definitionId = 1234))
+    expect_error(object = getConceptSetConceptIds(baseUrl = baseUrl, setId = 1234))
+    expect_error(object = insertCohortDefinitionSetInPackage(baseUrl = baseUrl, fileName = "conceptsetids.csv"))
+    expect_error(object = getCohortGenerationStatuses(baseUrl = baseUrl, definitionIds = c(1234), sourceKeys = c("CDM")))
+    expect_error(object = invokeCohortSetGeneration(baseUrl = baseUrl, definitionIds = c(1234), sourceKeys = c("CDM")))
+  }
 })


### PR DESCRIPTION
To fix #16, added support for numeric IP WebAPI base URLs by adding a second regex string to validate against.