### PR TITLE
Use open="wb" when writing text file to avoid extra linebreaks in output file.

### DIFF
--- a/R/WebApiTools.R
+++ b/R/WebApiTools.R
@@ -151,7 +151,7 @@ insertCohortDefinitionInPackage <- function(definitionId,
     dir.create("inst/sql/sql_server", recursive = TRUE)
   }
 
-  fileConn <- file(file.path("inst/sql/sql_server", paste(name, "sql", sep = ".")))
+  fileConn <- file(file.path("inst/sql/sql_server", paste(name, "sql", sep = ".")), open="wb")
   writeLines(sql, fileConn)
   close(fileConn)
 }


### PR DESCRIPTION
When using insertCohortDefinitionInPackage, the imported SQL has extra line-feed characters in it, described in this SO post: 
https://stackoverflow.com/questions/56192521/cat-appends-cr-to-output-in-r?noredirect=1#comment99011251_56192521

The solution was to open the file for writing using the `open="wb"` option, that will write the text in a binary form, which avoids the corruption by `cat()`.
